### PR TITLE
undefined reference `digitalPinToPinName` with mbed@2.5.2

### DIFF
--- a/src/OV767X.cpp
+++ b/src/OV767X.cpp
@@ -8,6 +8,7 @@
 #include <Wire.h>
 
 #include "OV767X.h"
+#include "pinDefinitions.h"
 
 // if not defined in the variant
 #ifndef digitalPinToBitMask


### PR DESCRIPTION
Using `mbed_nano@2.5.2` I get the following build errors:

``` sh
/tmp/arduino-sketch-DA796E73E66DC4EC175B4978B42EC20B/libraries/Arduino_OV767X/objs.a(OV767X.cpp.o): In function `OV767X::begin(int, int, int)':
/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:138: undefined reference to `digitalPinToPinName(unsigned char)'                                                          
/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:139: undefined reference to `digitalPinToPinName(unsigned char)'
/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:140: undefined reference to `digitalPinToPinName(unsigned char)'
/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:141: undefined reference to `digitalPinToPinName(unsigned char)'
/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:142: undefined reference to `digitalPinToPinName(unsigned char)'
/tmp/arduino-sketch-DA796E73E66DC4EC175B4978B42EC20B/libraries/Arduino_OV767X/objs.a(OV767X.cpp.o):/home/raul/Arduino/libraries/Arduino_OV767X/src/OV767X.cpp:143: more undefined references to `digitalPinToPinName(unsigned char)' follow
collect2: error: ld returned 1 exit status
```