### PR TITLE
Added OV7675 support

### DIFF
--- a/src/OV767X.cpp
+++ b/src/OV767X.cpp
@@ -65,7 +65,7 @@ OV767X::~OV767X()
   }
 }
 
-int OV767X::begin(int resolution, int format, int fps)
+int OV767X::begin(int resolution, int format, int fps, int camera_name)
 {
   switch (resolution) {
     case VGA:
@@ -154,8 +154,8 @@ int OV767X::begin(int resolution, int format, int fps)
     return 0;
   }
 
-  ov7670_configure(_ov7670, 0 /*OV7670 = 0, OV7675 = 1*/, format, resolution, 16 /* MHz */, 
-                    0 /*pll bypass*/, 1 /* pclk_hb_disable */);
+  ov7670_configure(_ov7670, camera_name /*OV7670 = 0, OV7675 = 1*/, format, resolution, 
+                    16 /* MHz */, 0 /*pll bypass*/, 1 /* pclk_hb_disable */);
 
   if (ov7670_s_power(_ov7670, 1)) {
     end();
@@ -198,12 +198,20 @@ int OV767X::height() const
 
 int OV767X::bitsPerPixel() const
 {
-  return _bytesPerPixel * 8;
+  if (_grayscale) {
+    return 8;
+  } else {
+    return _bytesPerPixel * 8;
+  }
 }
 
 int OV767X::bytesPerPixel() const
 {
-  return _bytesPerPixel;
+  if (_grayscale) {
+    return 1;
+  } else {
+    return _bytesPerPixel;
+  }
 }
 
 //

--- a/src/OV767X.h
+++ b/src/OV767X.h
@@ -53,7 +53,7 @@ public:
   virtual ~OV767X();
 
   // Supported FPS: 1, 5, 10, 15, 30
-  int begin(int resolution, int format, int fps, int camera_name = OV7675); 
+  int begin(int resolution, int format, int fps, int camera_name = OV7670); 
   void end();
 
   // must be called after Camera.begin():

--- a/src/OV767X.h
+++ b/src/OV767X.h
@@ -33,6 +33,12 @@ enum
 
 enum
 {
+  OV7670 = 0,
+  OV7675 = 1
+};
+
+enum
+{
   VGA = 0,  // 640x480
   CIF = 1,  // 352x240
   QVGA = 2, // 320x240
@@ -46,7 +52,8 @@ public:
   OV767X();
   virtual ~OV767X();
 
-  int begin(int resolution, int format, int fps); // Supported FPS: 1, 5, 10, 15, 30
+  // Supported FPS: 1, 5, 10, 15, 30
+  int begin(int resolution, int format, int fps, int camera_name = OV7675); 
   void end();
 
   // must be called after Camera.begin():


### PR DESCRIPTION
* Added parameter to begin() that allows users to select between OV7670 and OV7675. The default is set to OV7670, so it should not break any previous code that relies on this library.
* Added conditional return to bits/bytes per pixel functions so that grayscale bits/bytes per pixel are reported correctly.
* Tested successfully on an OV7675.
